### PR TITLE
[FIX]: package-lock.json added to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+package-lock.json/


### PR DESCRIPTION
Fixed. package-lock.json is no longer here